### PR TITLE
Falsche Variable beim Algorithmus

### DIFF
--- a/chapters/sections-alma1/rechnerarithmetik.tex
+++ b/chapters/sections-alma1/rechnerarithmetik.tex
@@ -147,7 +147,7 @@ Wir können die Genauigkeit von $x_2$ erhöhen, indem wir den Wurzelsatz von Vie
  \KwData{$p,q \in  \R$ so ,dass \eqref{eqn:pq} lösbar ist.}
  \KwResult{Nullstellen $x_1,x_2$ \eqref{eqn:pq}.}
  $d= \sqrt[2]{p \cdot p -q}$ \\
- \If{$q \ge 0$}{$x_1=p+d$
+ \If{$p \ge 0$}{$x_1=p+d$
  \Else{$x_1=p-d$}}
  $x_2=\frac{q}{x_1}$
  \end{algorithm}


### PR DESCRIPTION
An der Stelle sollte ein p statt einem q stehen. Ich habe das mit meinen Notizen, den Notizen von Dölz und dem "Skript" von ECampus verglichen.