### PR TITLE
Nur ein Tippfehler

### DIFF
--- a/chapters/sections-alma1/vorwärts-rückwärts-analyse.tex
+++ b/chapters/sections-alma1/vorwärts-rückwärts-analyse.tex
@@ -23,7 +23,7 @@ Bei der \emph{Rückwertsanalyse} geschieht die Verfolgung des Fehlers hingegen s
 Betrachte $f(x,y)=x+y$ \\
 \begin{itemize}
 	\item Vorwärtsanalyse: $\boxed{f} = x \boxplus y= (x+y)(1+\varepsilon)$
-	\item Rückwärtsanalyse: $x \boxplus y= x(1+\varepsilon)+y(1+\varepsilon)= f(x(1+\varepsilon), y(1+\varepsilon)$
+	\item Rückwärtsanalyse: $x \boxplus y= x(1+\varepsilon)+y(1+\varepsilon)= f(x(1+\varepsilon), y(1+\varepsilon))$
 \end{itemize}
 mit $|\varepsilon|\le \varepsilon_{mach}$
 \end{example}


### PR DESCRIPTION
Die Zeilen 43 bis 48 (die Fehleranalyse zur NST Berechnung mit pq-Formel) müsste eigentlich noch ergänzt werden. Im Moment fehlen einfach noch ein paar Schritte, aber bisher ist mir noch keine schöne Variante eingefallen, wie sich das schön in Latex editieren lässt. (Das wesentliche Problem für mich ist, dass ein paar der Gleichheitszeichen sich eigentlich nur auf den Teil unter der Wurzel beziehen. Man das aber in der jetzigen Form nicht wirklich erkennen kann.)